### PR TITLE
♻️  Refactor: swagger 요청 경로에 /api prefix 붙이기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,6 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
-	// Spring doc
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/Tokkit_server/config/SwaggerConfig.java
+++ b/src/main/java/com/example/Tokkit_server/config/SwaggerConfig.java
@@ -34,9 +34,9 @@ public class SwaggerConfig {
                 .addList("accessTokenAuth")
                 .addList("refreshTokenAuth");
 
-        //  실제 로컬 서버 주소로 변경
+        // 서버 URL에 /api 추가
         Server localServer = new Server();
-        localServer.setUrl("http://localhost:8080");
+        localServer.setUrl("http://localhost:8080/api");
 
         return new OpenAPI()
                 .components(new Components()

--- a/src/main/java/com/example/Tokkit_server/config/SwaggerConfig.java
+++ b/src/main/java/com/example/Tokkit_server/config/SwaggerConfig.java
@@ -36,7 +36,7 @@ public class SwaggerConfig {
 
         // 서버 URL에 /api 추가
         Server localServer = new Server();
-        localServer.setUrl("http://localhost:8080/api");
+        localServer.setUrl("http://localhost:8080");
 
         return new OpenAPI()
                 .components(new Components()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,9 @@ spring:
         hbm2ddl:
           auto: none
         default_batch_fetch_size: 1000
+
+springdoc:
+  api-docs:
+    path: /api/v3/api-docs
+  swagger-ui:
+    path: /api/swagger-ui.html


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #13 

## 📌 개요
- 개발계를 nginx로 구성하는 도중 /api로 오는 요청만 백엔드로 프록시 하게 해두었으나, swagger같은 경우는 /api로 시작하지 않아서 next.js로 proxy되는 이슈 발생
- swagger config를 수정해서 prefix를 달아두고 nginx에서 정상적으로 routing되게 수정
- 로컬 같은 경우에도 localhost:8080/api/swagger-ui/index.html로 요청하면 정상적으로 swagger 사용가능

## 🔁 변경 사항

## 📸 스크린샷 (선택)
![{5A38D017-FE89-4F38-8605-BAE01C984BCE}](https://github.com/user-attachments/assets/2e5a502a-9aad-4e4e-a864-f3c7187db3aa)

## 👀 기타 더 이야기해볼 점 (선택)

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
