### PR TITLE
fix: jwt 인증 필터 충돌 에러 해결

### DIFF
--- a/src/main/java/com/example/Tokkit_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/Tokkit_server/global/config/SecurityConfig.java
@@ -104,13 +104,12 @@ public class SecurityConfig {
                 .securityMatcher(
                         "/api/users/**",
                         "/api/ocr/**",
-                        "/api/vouchers/**",
-                        "/api/my-vouchers/**",
-                        "/api/store/**",
-                        "/api/wallet/**",
-                        "/api/notice/**",
-                        "/api/notifications/**",
-                        "/api/regions/**"
+                        "/api/users/vouchers/**",
+                        "/api/users/my-vouchers/**",
+                        "/api/users/store/**",
+                        "/api/users/wallet/**",
+                        "/api/users/notice/**",
+                        "/api/users/notifications/**"
                 )
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
@@ -150,12 +149,11 @@ public class SecurityConfig {
                 .securityMatcher(
                         "/api/merchants/**",
                         "/api/ocr/**",
-                        "/api/vouchers/**",
-                        "/api/my-vouchers/**",
-                        "/api/store/**",
-                        "/api/wallet/**",
-                        "/api/notice/**",
-                        "/api/notifications/**",
+                        "/api/merchants/vouchers/**",
+                        "/api/merchants/my-vouchers/**",
+                        "/api/merchants/wallet/**",
+                        "/api/merchants/notice/**",
+                        "/api/merchants/notifications/**",
                         "/api/regions/**"
                 )
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))

--- a/src/main/java/com/example/Tokkit_server/merchant/filter/MerchantJwtAuthenticationFilter.java
+++ b/src/main/java/com/example/Tokkit_server/merchant/filter/MerchantJwtAuthenticationFilter.java
@@ -31,6 +31,14 @@ public class MerchantJwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        // 유저 요청 건너뛰기
+        String uri = request.getRequestURI();
+
+        if (uri.startsWith("/api/users/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String bearerToken = request.getHeader("Authorization");
 
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
@@ -45,8 +53,8 @@ public class MerchantJwtAuthenticationFilter extends OncePerRequestFilter {
 
                 CustomMerchantDetails merchantDetails = new CustomMerchantDetails(
                         id,
-                        businessNumber,
                         email,
+                        businessNumber,
                         null,
                         role
                 );
@@ -55,6 +63,8 @@ public class MerchantJwtAuthenticationFilter extends OncePerRequestFilter {
                         new UsernamePasswordAuthenticationToken(merchantDetails, null, merchantDetails.getAuthorities());
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info("[MerchantJwtAuthenticationFilter] 인증 성공: merchantId={}, email={}", merchantDetails.getId(), merchantDetails.getEmail());
 
             } catch (io.jsonwebtoken.ExpiredJwtException e) {
                 log.warn("[MerchantJwtAuthenticationFilter] 만료된 토큰입니다: {}", e.getMessage());

--- a/src/main/java/com/example/Tokkit_server/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/Tokkit_server/notice/controller/NoticeController.java
@@ -12,7 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/notice")
+@RequestMapping("/api/users/notice")
 @RequiredArgsConstructor
 @Tag(name = "Notice", description = "공지사항 관련 API")
 public class NoticeController {

--- a/src/main/java/com/example/Tokkit_server/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/Tokkit_server/notification/controller/NotificationController.java
@@ -16,7 +16,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/notifications")
+@RequestMapping("/api/users/notifications")
 @RequiredArgsConstructor
 @Tag(name = "Notification", description = "알림 관련 API입니다.")
 public class NotificationController {

--- a/src/main/java/com/example/Tokkit_server/notification/controller/NotificationSettingController.java
+++ b/src/main/java/com/example/Tokkit_server/notification/controller/NotificationSettingController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/notifications/setting")
+@RequestMapping("/api/users/notifications/setting")
 @RequiredArgsConstructor
 @Tag(name = "NotificationSetting", description = "알림 설정 관련 API입니다.")
 public class NotificationSettingController {

--- a/src/main/java/com/example/Tokkit_server/store/controller/StoreController.java
+++ b/src/main/java/com/example/Tokkit_server/store/controller/StoreController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/store")
+@RequestMapping("/api/users/store")
 @RequiredArgsConstructor
 @Tag(name = "Store", description = "가맹점 관련 API")
 

--- a/src/main/java/com/example/Tokkit_server/user/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/Tokkit_server/user/filter/JwtAuthenticationFilter.java
@@ -28,6 +28,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        // 가맹점 요청 건너뛰기
+        String uri = request.getRequestURI();
+
+        if (uri.startsWith("/api/merchants/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String bearerToken = request.getHeader("Authorization");
 
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {

--- a/src/main/java/com/example/Tokkit_server/voucher/controller/VoucherController.java
+++ b/src/main/java/com/example/Tokkit_server/voucher/controller/VoucherController.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/vouchers")
+@RequestMapping("/api/users/vouchers")
 @Tag(name = "Vouchers", description = "바우처 관련 API")
 public class VoucherController {
 

--- a/src/main/java/com/example/Tokkit_server/voucher_ownership/controller/VoucherOwnershipController.java
+++ b/src/main/java/com/example/Tokkit_server/voucher_ownership/controller/VoucherOwnershipController.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/my-vouchers")
+@RequestMapping("/api/users/my-vouchers")
 @RequiredArgsConstructor
 @Tag(name = "MyVouchers", description = "내 바우처 관련 API")
 public class VoucherOwnershipController {

--- a/src/main/java/com/example/Tokkit_server/wallet/controller/MerchantWalletController.java
+++ b/src/main/java/com/example/Tokkit_server/wallet/controller/MerchantWalletController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/merchant/wallet")
+@RequestMapping("/api/merchants/wallet")
 @RequiredArgsConstructor
 @Tag(name = "Merchant Wallet", description = "가맹점주 전자지갑 관련 API")
 public class MerchantWalletController {
@@ -25,7 +25,7 @@ public class MerchantWalletController {
 
     @GetMapping("/balance")
     @Operation(summary = "잔액 조회", description = "사용자 ID로 잔액 조회")
-    public ApiResponse<WalletBalanceResponse> getBalance(@AuthenticationPrincipal CustomMerchantDetails merchantDetails) {
+    public ApiResponse<MerchantWalletBalanceResponse> getBalance(@AuthenticationPrincipal CustomMerchantDetails merchantDetails) {
         return ApiResponse.onSuccess(commandService.getWalletBalance(merchantDetails.getId()));
     }
 

--- a/src/main/java/com/example/Tokkit_server/wallet/controller/WalletController.java
+++ b/src/main/java/com/example/Tokkit_server/wallet/controller/WalletController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/wallet")
+@RequestMapping("/api/users/wallet")
 @RequiredArgsConstructor
 @Tag(name = "Wallet", description = "전자지갑 관련 API")
 public class WalletController {

--- a/src/main/java/com/example/Tokkit_server/wallet/dto/response/MerchantWalletBalanceResponse.java
+++ b/src/main/java/com/example/Tokkit_server/wallet/dto/response/MerchantWalletBalanceResponse.java
@@ -1,0 +1,15 @@
+package com.example.Tokkit_server.wallet.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MerchantWalletBalanceResponse {
+    private Long depositBalance;
+    private Long tokenBalance;
+    private String storeName;
+    private String accountNumber;
+}

--- a/src/main/java/com/example/Tokkit_server/wallet/service/command/MerchantWalletCommandService.java
+++ b/src/main/java/com/example/Tokkit_server/wallet/service/command/MerchantWalletCommandService.java
@@ -7,8 +7,8 @@ import com.example.Tokkit_server.transaction.enums.TransactionStatus;
 import com.example.Tokkit_server.transaction.enums.TransactionType;
 import com.example.Tokkit_server.transaction.repository.TransactionRepository;
 import com.example.Tokkit_server.transaction.service.query.TransactionLogService;
+import com.example.Tokkit_server.wallet.dto.response.MerchantWalletBalanceResponse;
 import com.example.Tokkit_server.wallet.dto.response.TransactionHistoryResponse;
-import com.example.Tokkit_server.wallet.dto.response.WalletBalanceResponse;
 import com.example.Tokkit_server.wallet.entity.Wallet;
 import com.example.Tokkit_server.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
@@ -45,11 +45,11 @@ public class MerchantWalletCommandService {
     /**
      * 지갑 잔액 조회
      */
-    public WalletBalanceResponse getWalletBalance(Long merchantId) {
+    public MerchantWalletBalanceResponse getWalletBalance(Long merchantId) {
         Wallet wallet = walletRepository.findByMerchant_Id(merchantId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MERCHANT_WALLET_NOT_FOUND));
 
-        return new WalletBalanceResponse(wallet.getDepositBalance(), wallet.getTokenBalance(), wallet.getMerchant().getName(), wallet.getAccountNumber());
+        return new MerchantWalletBalanceResponse(wallet.getDepositBalance(), wallet.getTokenBalance(), wallet.getMerchant().getStore().getStoreName(), wallet.getAccountNumber());
     }
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #8 

## 📌 개요
- JWT 인증 필터 충돌로 인한 에러 해결

## 🔁 변경 사항
- `JwtAuthenticationFilter`와 `MerchantJwtAuthenticationFilter`에서 URI 분기 처리
- 각각 api들의 역할에 따라 api 엔드포인트 통일

## 📸 스크린샷 (선택)
<img width="727" alt="image" src="https://github.com/user-attachments/assets/dba60aa9-f457-48ea-bbf2-71aaf5553ac4" />

## 👀 기타 더 이야기해볼 점 (선택)
- 추가적으로 api를 개발하게 된다면 해당 api가 어떤 사용자(ex. 유저 or 가맹점주)를 위한 것인지 파악 후 URI에 `/api/users/~` 혹은 `/api/merchants/~`의 규칙을 맞춰서 개발 부탁드립니다 🫡

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
